### PR TITLE
fix: optimize PIGNN query

### DIFF
--- a/app/data/query.tsv
+++ b/app/data/query.tsv
@@ -6,4 +6,4 @@ Koopman Theory	(koopman*) | ("transformations in hilbert space") | ("linear tran
 Symbolic regression	(("symbolic regression") | ("sparse identification of nonlinear dynamics") -("genetic programming") -("neural differential equations") -(evolution) -("gene expression"))
 PINNs	("physics-informed neural computing") | ("physics-informed neural networks") | ("physics-informed deep learning")
 Neural ODEs	("neural ordinary differential equation") | ("neural ODE") | ("graph neural differential equation")  | ("graph neural ODEs") | ("neural ODE solvers")
-Physics-informed GNNs	(("graph networks") + ("physics constrain*"") | ("Differentiable Learned Simulator*"))
+Physics-informed GNNs	(("graph networks") + (physics constrain*) | ("Differentiable Learned Simulator*"))


### PR DESCRIPTION
## Description
@lilijap @awmulyadi @dmccloskey The problem below may be relevant for all of us to take note of (until at least the recommendation API is implemented).

The [current deployment](https://virtualpatientengine.github.io/literatureSurvey/Physics-informed_GNNs/) (1.5.1) of this repo displays only one article under the tab "Physics-informed GNNs" (PIGNN).
![image](https://github.com/VirtualPatientEngine/literatureSurvey/assets/43615259/a4820cc4-634e-49e4-bbb3-a6d8c1ea5594)

> I investigated the issue and determined that programmatically, the API and code function properly. The problem, however, lies with the syntax we define search queries.


### I suspect the following reasons would have contributed to the odd behaviour:
1. [The PIGNN query](https://github.com/VirtualPatientEngine/literatureSurvey/blob/1de20a72767e70cc97ad4d7d9eadb46fea6d8e62/app/data/query.tsv#L9) in the current deployment contains an extra ```"``` in ```("physics constrain*"")```
2. Wrapping a query with ```"``` can reduce the number of articles drastically. Check out the syntax that can be used to build your queries [here](https://api.semanticscholar.org/api-docs/#tag/Paper-Data/operation/get_graph_paper_bulk_search).

### Here are 2 tests to validate my hypothesis:
1. Changing ```"physics constrain*"``` to ```physics constrain*``` already increased the num of articles to 7 (see below)
Search query for PIGNN: ```(("graph networks") + (physics constrain*) | ("Differentiable Learned Simulator*"))```
![image](https://github.com/VirtualPatientEngine/literatureSurvey/assets/43615259/cc7122df-9cb4-4f9a-9be0-bf8ce6a135d6)

2. I also ran the current deployment's code on the search query from a previous deployment (v1.4.0; released on Monday), which ran fine.
Search query for PIGNN (v1.4.0): ```((graph networks) + (physics constrain*)) | ("learned simulator"~1) | ("learned simulation"~1)```
**Please note** that this search didn't contain ```"``` around ```physics constrain*```, and as a result I suspect we see more than one entry (see the image below).
![image](https://github.com/VirtualPatientEngine/literatureSurvey/assets/43615259/71309249-3992-4d0b-9875-fc918928e5c2)

### TLDR;
We will have to strictly follow the S2 syntax; otherwise, the results may behave oddly. The good news is that once we have the recommendation API implemented, we hopefully won't have to deal with this annoyance anymore. But until then, I would like to suggest that everyone strictly follows [S2's syntax](https://api.semanticscholar.org/api-docs/#tag/Paper-Data/operation/get_graph_paper_bulk_search) to avoid it.

### Pro-Tip
Use ```mkdocs serve``` (in case you didn't know) on your local machine to launch the website on your localhost. This enables you to view the website on your machine and identify any errors or unexpected behavior well in advance of committing changes to GitHub. Checkout the [README](https://github.com/VirtualPatientEngine/literatureSurvey/blob/main/README.md) to know more. I have added this feature in all web application-related repos.

### Sharing the URL with our stakeholders
I'd suggest after this PR is merged with the develop branch, @lilijap can fetch it and update the search queries based on S2 syntax (if need be). Once the queries are updated/optimized, please push your code to develop and merge it with the main branch, and Actions will take care of the release. (@dmccloskey @lilijap, sounds OK?)

@awmulyadi, do you mind making sure the above malarkey is not causing odd behaviour in your web app too :-)

PS: The S2 website uses free text search while the API has a syntax so you can expect certain differences between the two.

Fixes # (issue) None

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
- [X] Images from the local deployment (see the description above)

# Checklist:
- [X] My code follows the style guidelines mentioned in the code management policies
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/MkDocs (**NA**)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (**NA**)
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
